### PR TITLE
Update IoT samples to .NET 10 and latest packages

### DIFF
--- a/quickstarts/SenseHat.Quickstart/SenseHat.Quickstart.csproj
+++ b/quickstarts/SenseHat.Quickstart/SenseHat.Quickstart.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Iot.Device.Bindings" Version="3.2.0-*" />
+    <PackageReference Include="Iot.Device.Bindings" Version="4.1.0" />
   </ItemGroup>
 
 </Project>

--- a/setup/sensehat-quickstart.sh
+++ b/setup/sensehat-quickstart.sh
@@ -1,5 +1,5 @@
 # Script parameters
-declare dotnetVersion="8.0.303"
+declare dotnetVersion="10.0.103"
 declare iotBits="https://github.com/MicrosoftDocs/dotnet-iot-assets"
 
 # Text formatting

--- a/tutorials/AdcTutorial/AdcTutorial.csproj
+++ b/tutorials/AdcTutorial/AdcTutorial.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Iot.Device.Bindings" Version="3.2.0-*" />
+    <PackageReference Include="Iot.Device.Bindings" Version="4.1.0" />
   </ItemGroup>
 
 </Project>

--- a/tutorials/BlinkTutorial/BlinkTutorial.csproj
+++ b/tutorials/BlinkTutorial/BlinkTutorial.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="3.2.0-*" />
+    <PackageReference Include="System.Device.Gpio" Version="4.0.1" />
   </ItemGroup>
 
 </Project>

--- a/tutorials/InputTutorial/InputTutorial.csproj
+++ b/tutorials/InputTutorial/InputTutorial.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="3.2.0-*" />
+    <PackageReference Include="System.Device.Gpio" Version="4.0.1" />
   </ItemGroup>
   
 </Project>

--- a/tutorials/LcdTutorial/LcdTutorial.csproj
+++ b/tutorials/LcdTutorial/LcdTutorial.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Iot.Device.Bindings" Version="3.2.0-*" />
+    <PackageReference Include="Iot.Device.Bindings" Version="4.1.0" />
   </ItemGroup>
 
 </Project>

--- a/tutorials/LcdTutorial/Program.cs
+++ b/tutorials/LcdTutorial/Program.cs
@@ -15,7 +15,7 @@ using var lcd = new Lcd2004(registerSelectPin: 0,
                         backlightPin: 3, 
                         backlightBrightness: 0.1f, 
                         readWritePin: 1, 
-                        controller: new GpioController(PinNumberingScheme.Logical, driver));
+                        controller: new GpioController(driver));
 int currentLine = 0;
 
 while (true)

--- a/tutorials/SensorTutorial/SensorTutorial.csproj
+++ b/tutorials/SensorTutorial/SensorTutorial.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Iot.Device.Bindings" Version="3.2.0-*" />
+    <PackageReference Include="Iot.Device.Bindings" Version="4.1.0" />
   </ItemGroup>
 
 </Project>

--- a/tutorials/ft232h/ft232h.gpio/ft232h.gpio.csproj
+++ b/tutorials/ft232h/ft232h.gpio/ft232h.gpio.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IoT.Device.Bindings" Version="3.2.0" />
+    <PackageReference Include="Iot.Device.Bindings" Version="4.1.0" />
   </ItemGroup>
 
 </Project>

--- a/tutorials/ft232h/ft232h.i2c/ft232h.i2c.csproj
+++ b/tutorials/ft232h/ft232h.i2c/ft232h.i2c.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IoT.Device.Bindings" Version="3.2.0" />
+    <PackageReference Include="Iot.Device.Bindings" Version="4.1.0" />
   </ItemGroup>
 
 </Project>

--- a/tutorials/ft232h/ft232h.list/ft232h.list.csproj
+++ b/tutorials/ft232h/ft232h.list/ft232h.list.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IoT.Device.Bindings" Version="3.2.0" />
+    <PackageReference Include="Iot.Device.Bindings" Version="4.1.0" />
   </ItemGroup>
 
 </Project>

--- a/tutorials/ft232h/ft232h.spi/ft232h.spi.csproj
+++ b/tutorials/ft232h/ft232h.spi/ft232h.spi.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IoT.Device.Bindings" Version="3.2.0" />
+    <PackageReference Include="Iot.Device.Bindings" Version="4.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Update all 10 sample projects from `net8.0` to `net10.0`
- Update `System.Device.Gpio` from 3.2.0 to **4.0.1**
- Update `Iot.Device.Bindings` from 3.2.0 to **4.1.0**
- Fix `IoT.Device.Bindings` package name casing in ft232h projects
- Fix LcdTutorial breaking change: remove deprecated `PinNumberingScheme.Logical` from `GpioController` constructor (removed in System.Device.Gpio v4.x)
- Update `sensehat-quickstart.sh` SDK version from `8.0.303` to `10.0.103`

## Companion PR
Companion docs PR: https://github.com/dotnet/docs/pull/52111